### PR TITLE
Update README with new Z height, formatting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # VzBoT-Vz235
-[![Discord Invite](https://discordapp.com/api/guilds/829828765512106054/widget.png?style=banner2)](https://discord.gg/KWZWvCMxCq)
 
+The Vz-235 is a smaller sized VzBoT with a bed print size of 235 x 235 x 200 mm and an optional AWD setup, for which we named the Kinematics "QuadXY" (also known as AWD).
 
-The Vz-235 is a smaller sized VzBoT with a bed print size of 235 x 235 x 240 mm and an optional AWD setup, for which we named the Kinematics "QuadXY" 
+You can find the complete web model without CAD-Software here:
 
-You can find the complete web model without CAD-Software here: 
 - [Printed Vz-235](https://a360.co/3OvcNKD)
 - [CNC Full Mellow kit](https://a360.co/3Zi1SXN) 
 
-# Buy the full printer kit here: https://s.click.aliexpress.com/e/_DldJGNB 
+## Purchase
 
+AWD kit by Mellow3D: [Mellow Genuine DIY VzBoT AWD 235 VZ235 3D Printer Kit](https://s.click.aliexpress.com/e/_DldJGNB)
 
 The AWD version has been proven to be great for high speed printing without loss of quality!
 
 ![VZ_235_QuadXY](https://user-images.githubusercontent.com/93674339/156187512-b45556b6-765a-4367-a894-3cf041b70728.jpg)
 
+## Support
 
+[![Discord Invite](https://discordapp.com/api/guilds/829828765512106054/widget.png?style=banner2)](https://discord.gg/KWZWvCMxCq)
 
+## License
 
-This project is licensed as
-![image](https://user-images.githubusercontent.com/37383368/139769027-7267da5b-7f58-499d-96bc-e41d164a3aac.png)
-
-https://creativecommons.org/licenses/by-nc/4.0/
+This project is licensed as Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+[![image](https://user-images.githubusercontent.com/37383368/139769027-7267da5b-7f58-499d-96bc-e41d164a3aac.png)](https://creativecommons.org/licenses/by-nc/4.0/)


### PR DESCRIPTION
Update Z-height, update readme formatting slightly

The originally posted Z height was in error. The printer was never designed for 240mm Z height / travel

![image](https://github.com/VzBoT3D/VzBoT-Vz235/assets/16231288/82a416b4-3d72-4559-9375-2f632b4b8841)
