### PR TITLE
match default klipper path

### DIFF
--- a/Firmware/235AWD-printer.cfg
+++ b/Firmware/235AWD-printer.cfg
@@ -12,7 +12,7 @@
 [display_status]
 [exclude_object]
 [virtual_sdcard]
-path: ~/gcode_files
+path: ~/printer_data/gcodes
 [pause_resume]
 recover_velocity: 350
 


### PR DESCRIPTION
The default Klipper path for the virtual_sdcard is ~/printer_data/gcodes, so we will use that original path to prevent users from becoming confused.